### PR TITLE
feature: Add rate limiting functionality to the application

### DIFF
--- a/SmartNeighborhoodAPI/Controllers/AppControllerBase.cs
+++ b/SmartNeighborhoodAPI/Controllers/AppControllerBase.cs
@@ -1,10 +1,12 @@
 ﻿using System.Net;
+using Microsoft.AspNetCore.RateLimiting;
 using SmartNeighborhoodAPI.Helpers.Attrbuites;
 
 namespace SmartNeighborhoodAPI.Controllers
 {
     [ApiController]
     [ValidateActionFilter]
+    [EnableRateLimiting("fixed-window")]
     [Route("api/[controller]")]
     public class AppControllerBase : ControllerBase
     {

--- a/SmartNeighborhoodAPI/Controllers/BlocksController.cs
+++ b/SmartNeighborhoodAPI/Controllers/BlocksController.cs
@@ -1,4 +1,6 @@
-﻿namespace SmartNeighborhoodAPI.Controllers
+﻿using Microsoft.AspNetCore.RateLimiting;
+
+namespace SmartNeighborhoodAPI.Controllers
 {
     public class BlocksController : AppControllerBase
     {

--- a/SmartNeighborhoodAPI/Program.cs
+++ b/SmartNeighborhoodAPI/Program.cs
@@ -1,6 +1,10 @@
+using System.Net;
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.RateLimiting;
 using OurProjectSmartNeiborhood.Services;
 using Serilog;
 using SmartNeighborhoodAPI.Entites;
@@ -9,7 +13,6 @@ using SmartNeighborhoodAPI.Interfaces;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-
 
 builder.Services.AddCors(options =>
 {
@@ -64,6 +67,41 @@ Log.Logger = new LoggerConfiguration()
 
 
 builder.Host.UseSerilog();
+
+builder.Services.AddRateLimiter(options =>
+{
+    options.AddPolicy("fixed-window", context =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 5,
+                Window = TimeSpan.FromSeconds(10),
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+            }
+        )
+    );
+
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+    options.OnRejected = async (context, token) =>
+    {
+        context.HttpContext.Response.ContentType = "application/json";
+
+        var response = ApiResponse<object>.Error(
+            HttpStatusCode.TooManyRequests,
+            "You have exceeded the allowed number of requests. Try again later."
+        );
+
+        var json = JsonSerializer.Serialize(response);
+        context.HttpContext.Response.StatusCode = (int)HttpStatusCode.TooManyRequests;
+
+        await context.HttpContext.Response.WriteAsync(json, token);
+    };
+});
+
+
 
 //var jwt = builder.Configuration.GetSection("Jwt").Get<JWT>();
 //builder.Services.AddAuthentication(options =>
@@ -122,6 +160,8 @@ app.UseSwaggerUI(options =>
 {
     options.RoutePrefix = "swagger";
 });
+app.UseRateLimiter();
+
 app.UseStaticFiles(); 
 
 app.UseCors("AllowAll");


### PR DESCRIPTION
This commit introduces rate limiting by adding the `Microsoft.AspNetCore.RateLimiting` namespace and
the `[EnableRateLimiting("fixed-window")]` attribute to `AppControllerBase.cs`.

In `Program.cs`, new using directives are added,
and a rate limiter policy is configured to allow
5 requests per 10 seconds per IP address.
A 429 Too Many Requests response is returned
if the limit is exceeded, with a JSON error message. The application pipeline is updated to include
`app.UseRateLimiter()`, enhancing the application's ability to manage request rates and improve
robustness against potential abuse.