### PR TITLE
Add RequestTimingMiddleware for slow request logging

### DIFF
--- a/SmartNeighborhoodAPI/Middlewares/RequestTimingMiddleware.cs
+++ b/SmartNeighborhoodAPI/Middlewares/RequestTimingMiddleware.cs
@@ -1,0 +1,36 @@
+﻿using System.Diagnostics;
+
+namespace SmartNeighborhoodAPI.Middlewares
+{
+    public class RequestTimingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<RequestTimingMiddleware> _logger;
+        private readonly int _thresholdMs;
+
+        public RequestTimingMiddleware(RequestDelegate next, ILogger<RequestTimingMiddleware> logger, IConfiguration config)
+        {
+            _next = next;
+            _logger = logger;
+            _thresholdMs = config.GetValue<int>("Performance:SlowRequestThresholdMs", 1000);
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var sw = Stopwatch.StartNew();
+            await _next(context);
+            sw.Stop();
+
+            if (sw.ElapsedMilliseconds > _thresholdMs)
+            {
+                var method = context.Request.Method;
+                var path = context.Request.Path;
+                var ip = context.Connection.RemoteIpAddress?.ToString();
+
+                _logger.LogWarning("Slow request detected: {Method} {Path} took {Duration}ms from IP {IP}",
+                    method, path, sw.ElapsedMilliseconds, ip);
+            }
+        }
+    }
+
+}

--- a/SmartNeighborhoodAPI/Program.cs
+++ b/SmartNeighborhoodAPI/Program.cs
@@ -9,6 +9,7 @@ using OurProjectSmartNeiborhood.Services;
 using Serilog;
 using SmartNeighborhoodAPI.Entites;
 using SmartNeighborhoodAPI.Interfaces;
+using SmartNeighborhoodAPI.Middlewares;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -160,13 +161,14 @@ app.UseSwaggerUI(options =>
 {
     options.RoutePrefix = "swagger";
 });
+
 app.UseRateLimiter();
+app.UseMiddleware<RequestTimingMiddleware>();
 
-app.UseStaticFiles(); 
-
-app.UseCors("AllowAll");
+app.UseStaticFiles();
 app.UseHttpsRedirection();
 
+app.UseCors("AllowAll");
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/SmartNeighborhoodAPI/appsettings.json
+++ b/SmartNeighborhoodAPI/appsettings.json
@@ -33,6 +33,10 @@
     "Username": "mubark7382@gmail.com",
     "Password": "sdln rmsi sxtg mngq"
   },
+    "Performance": {
+      "SlowRequestThresholdMs": 1000
+    },
+
   "AllowedHosts": "*"
 }
 


### PR DESCRIPTION
- Introduced `RequestTimingMiddleware` to log requests exceeding a specified duration.
- Updated `Program.cs` to include the new middleware and adjusted middleware order.
- Added `Performance` section in `appsettings.json` with `SlowRequestThresholdMs` set to 1000 ms.