### PR TITLE
Feature: Add endpoint to chanage block manager

### DIFF
--- a/SmartNeighborhoodAPI/Controllers/BlocksController.cs
+++ b/SmartNeighborhoodAPI/Controllers/BlocksController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.RateLimiting;
+using SmartNeighborhoodAPI.Helpers.DTOs.Auth;
 
 namespace SmartNeighborhoodAPI.Controllers
 {
@@ -26,6 +27,11 @@ namespace SmartNeighborhoodAPI.Controllers
         public async Task<IActionResult> AddAsync(BlockDto BlockDto)
         {
             return Response(await _BlockServices.AddAsync(BlockDto));
+        }
+        [HttpPost("[action]")]
+        public async Task<IActionResult> ChangeBlockManager(ChangeBlockManagerDto blockManagerDto)
+        {
+            return Response(await _BlockServices.ChangeBlockManager(blockManagerDto));
         }
         [HttpGet("[action]")]
         public async Task<IActionResult> GetAllAsync()

--- a/SmartNeighborhoodAPI/Helpers/DTOs/Auth/ChangeBlockManagerDto.cs
+++ b/SmartNeighborhoodAPI/Helpers/DTOs/Auth/ChangeBlockManagerDto.cs
@@ -1,0 +1,18 @@
+﻿namespace SmartNeighborhoodAPI.Helpers.DTOs.Auth
+{
+    public class ChangeBlockManagerDto
+    {
+        [Required(ErrorMessage = "BlockId is required")]
+        public int BlockId { get; set; }
+
+        [Required(ErrorMessage = "Email is required")]
+        [EmailAddress]
+        public string Email { get; set; }
+
+        [Required(ErrorMessage = "Password is required")]
+        [MinLength(8, ErrorMessage = "Password must be at least 8 characters long")]
+        public string Password { get; set; }
+        [Required(ErrorMessage = "PersonId is required")]
+        public int PersonId { get; set; }
+    }
+}

--- a/SmartNeighborhoodAPI/Interfaces/IAuthService.cs
+++ b/SmartNeighborhoodAPI/Interfaces/IAuthService.cs
@@ -4,7 +4,8 @@ namespace SmartNeighborhoodAPI.Interfaces
 {
     public interface IAuthService
     {
-        Task<ApiResponse<UserResponse>> CreateBlockManagerAsync(CreateBlockManagerDto registerDto);
+        Task<ApiResponse<UserResponse>> CreateBlockManagerAccountAsync(CreateBlockManagerDto registerDto);
+        Task<ApiResponse<UserResponse>> DeleteBlockManagerAccountByIdAsync(string managerId);
         Task<ApiResponse<UserResponse>> LoginAsync(LoginDto loginDto);
         Task<ApiResponse<UserResponse>> ConfirmEmailOtp(ConfirmEmailOtpDto emailOtpDto);
     }

--- a/SmartNeighborhoodAPI/Services/AuthService.cs
+++ b/SmartNeighborhoodAPI/Services/AuthService.cs
@@ -60,7 +60,7 @@ namespace SmartNeighborhoodAPI.Services
         }
 
 
-        public async Task<ApiResponse<UserResponse>> CreateBlockManagerAsync(CreateBlockManagerDto dto)
+        public async Task<ApiResponse<UserResponse>> CreateBlockManagerAccountAsync(CreateBlockManagerDto dto)
         {
             _logger.LogInformation("Attempting to create a Block Manager for email: {Email}", dto.Email);
 
@@ -75,7 +75,7 @@ namespace SmartNeighborhoodAPI.Services
                 Email = dto.Email,
                 UserName = dto.Email,
                 PersonId = dto.PersonId,
-                IsActive = true
+                IsActive = false,
             };
 
             var result = await _userManager.CreateAsync(user, dto.Password);
@@ -111,6 +111,37 @@ namespace SmartNeighborhoodAPI.Services
 
             return ApiResponse<UserResponse>.Success(userResponse, "User registered successfully. OTP sent to email.");
         }
+
+        public async Task<ApiResponse<UserResponse>> DeleteBlockManagerAccountByIdAsync(string managerId)
+        {
+            _logger.LogInformation("Deleting Block Manager with ID: {ManagerId}", managerId);
+
+            var user = await _userManager.FindByIdAsync(managerId);
+            if (user == null)
+            {
+                _logger.LogWarning("Block Manager with ID '{ManagerId}' not found.", managerId);
+                return ApiResponse<UserResponse>.Error(HttpStatusCode.NotFound, "User not found.");
+            }
+
+            var deletionResult = await _userManager.DeleteAsync(user);
+            if (!deletionResult.Succeeded)
+            {
+                _logger.LogError("Failed to delete Block Manager with ID: {ManagerId}. Errors: {Errors}",
+                                 managerId, string.Join(", ", deletionResult.Errors.Select(e => e.Description)));
+                return ApiResponse<UserResponse>.Error(HttpStatusCode.InternalServerError, "Failed to delete user.");
+            }
+
+            var userResponse = new UserResponse
+            {
+                Id = user.Id,
+                Email = user.Email,
+            };
+
+            _logger.LogInformation("Successfully deleted Block Manager with ID: {ManagerId}", managerId);
+
+            return ApiResponse<UserResponse>.Success(userResponse);
+        }
+
 
         public async Task<ApiResponse<UserResponse>> ConfirmEmailOtp(ConfirmEmailOtpDto emailOtpDto)
         {

--- a/SmartNeighborhoodAPI/Services/BlockServices.cs
+++ b/SmartNeighborhoodAPI/Services/BlockServices.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.AspNetCore.Identity;
-using OurProjectSmartNeiborhood.Services;
-using SmartNeighborhoodAPI.Entites;
+﻿using SmartNeighborhoodAPI.Helpers.DTOs.Auth;
 using SmartNeighborhoodAPI.Interfaces;
 using System.Net;
 
@@ -40,6 +38,84 @@ namespace SmartNeighborhoodAPI.Services
 
             return ApiResponse<IEnumerable<RetrunBlockDto>>.Success(blocks);
         }
+
+        public async Task<ApiResponse<RetrunBlockDto>> ChangeBlockManager(ChangeBlockManagerDto blockManagerDto)
+        {
+            _logger.LogInformation("Initiating change of block manager for BlockId: {BlockId}, PersonId: {PersonId}",
+                blockManagerDto.BlockId, blockManagerDto.PersonId);
+
+            // Step 1: Validate Block
+            var block = await _context.Blocks.FindAsync(blockManagerDto.BlockId);
+            if (block == null)
+            {
+                _logger.LogWarning("Block with ID '{BlockId}' not found.", blockManagerDto.BlockId);
+                return ApiResponse<RetrunBlockDto>.Error(HttpStatusCode.NotFound, "Block not found.");
+            }
+
+            // Step 2: Validate Person
+            var person = await _context.People.FindAsync(blockManagerDto.PersonId);
+            if (person == null)
+            {
+                _logger.LogWarning("Person with ID '{PersonId}' not found.", blockManagerDto.PersonId);
+                return ApiResponse<RetrunBlockDto>.Error(HttpStatusCode.NotFound, "Person not found.");
+            }
+
+            // Step 3: Ensure the person is not already managing another block
+            var isAlreadyManager = _context.Blocks.Any(x => x.Manager.PersonId == person.Id);
+            if (isAlreadyManager)
+            {
+                _logger.LogWarning("Person with ID '{PersonId}' is already a manager of another block.", person.Id);
+                return ApiResponse<RetrunBlockDto>.Error(HttpStatusCode.Conflict, "This person is already assigned as a manager to another block.");
+            }
+
+            // Step 4: Create new manager account
+            var createResult = await _authService.CreateBlockManagerAccountAsync(new CreateBlockManagerDto
+            {
+                Email = blockManagerDto.Email,
+                Password = blockManagerDto.Password,
+                PersonId = blockManagerDto.PersonId
+            });
+
+            if (!createResult.IsSuccess)
+            {
+                _logger.LogError("Failed to create new block manager. Reason: {Reason}", createResult.Message);
+                return ApiResponse<RetrunBlockDto>.Error(createResult.StatusCode, createResult.Message, createResult.Errors);
+            }
+
+            string oldManagerId = block.ManagerId;
+            block.ManagerId = createResult.Data.Id;
+
+            // Step 5: Update block
+            _logger.LogInformation("Update Block with ID '{BlockId}'.", blockManagerDto.BlockId);
+            _context.Blocks.Update(block);
+            await _context.SaveChangesAsync();
+
+            // Step 6: Delete old manager
+            var deleteResult = await _authService.DeleteBlockManagerAccountByIdAsync(oldManagerId);
+            if (!deleteResult.IsSuccess)
+            {
+                _logger.LogError("Failed to delete old block manager with ID: {OldManagerId}", oldManagerId);
+                return ApiResponse<RetrunBlockDto>.Error(deleteResult.StatusCode, deleteResult.Message, deleteResult.Errors);
+            }
+
+            // Step 7: Prepare response
+            var returnBlockDto = new RetrunBlockDto
+            {
+                Id = block.Id,
+                Name = block.Name,
+                ManagerId = block.ManagerId,
+                PersonId = person.Id,
+                Email = createResult.Data.Email,
+                FullName = person.FullName
+            };
+
+            _logger.LogInformation("Block manager updated successfully for block '{BlockName}' (ID: {BlockId})",
+                block.Name, block.Id);
+
+            return ApiResponse<RetrunBlockDto>.Success(returnBlockDto,
+                "Block manager updated successfully. Login credentials sent via email.");
+        }
+
         public async Task<ApiResponse<RetrunBlockDto>> AddAsync(BlockDto blockDto)
         {
             _logger.LogInformation("Attempting to add a new block with name: {BlockName}", blockDto.Name);
@@ -65,7 +141,7 @@ namespace SmartNeighborhoodAPI.Services
                 Password = blockDto.Password
             };
 
-            var response = await _authService.CreateBlockManagerAsync(blockManagerDto);
+            var response = await _authService.CreateBlockManagerAccountAsync(blockManagerDto);
 
             if (!response.IsSuccess)
             {


### PR DESCRIPTION
- Introduced `ChangeBlockManager` endpoint in `BlocksController.cs` for updating block managers.
- Renamed `CreateBlockManagerAsync` to `CreateBlockManagerAccountAsync` in `IAuthService.cs` and added `DeleteBlockManagerAccountByIdAsync`.
- Updated `AuthService.cs` to reflect method renaming and adjusted user `IsActive` status during account creation.
- Enhanced `BlockServices.cs` with logic for changing block managers, including validation and account deletion.
- Added `ChangeBlockManagerDto` class for encapsulating data related to block manager changes with validation attributes.