### PR TITLE
Fix: handle deletion of Team with existing TeamMembers to avoid FK co…

### DIFF
--- a/SmartNeighborhoodAPI/Services/TeamsService.cs
+++ b/SmartNeighborhoodAPI/Services/TeamsService.cs
@@ -68,7 +68,7 @@ namespace SmartNeighborhoodAPI.Services
         {
             _logger.LogInformation("Attempting to delete team with ID {TeamId}", id);
 
-            var entity = await _context.Teams.FirstOrDefaultAsync(x => x.Id == id);
+            var entity = await _context.Teams.Include(x => x.TeamMembers).FirstOrDefaultAsync(x => x.Id == id);
             if (entity == null)
             {
                 _logger.LogWarning("Team with ID {TeamId} not found.", id);
@@ -122,8 +122,6 @@ namespace SmartNeighborhoodAPI.Services
 
             return ApiResponse<IEnumerable<CustomTeamDto>>.Success(teams, "تم جلب الفرق بنجاح");
         }
-
-
         public async Task<ApiResponse<TeamDto>> GetByIdAsync(int id)
         {
             //    var team = await _context.Teams.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);


### PR DESCRIPTION
…nstraint error

- Added logic to delete related TeamMembers before deleting the Team
- Prevented foreign key conflict on TeamId in TeamMembers table
- Ensures database integrity during team deletion