### PR TITLE
Feat: Add GetProjectBlocksWithBeneficiaryFamilies and GetProjectTeam

### DIFF
--- a/SmartNeighborhoodAPI/Controllers/ProjectController.cs
+++ b/SmartNeighborhoodAPI/Controllers/ProjectController.cs
@@ -63,6 +63,19 @@ namespace SmartNeighborhoodAPI.Controllers
             return Response(result);
         }
 
+        [HttpGet("details/{projectId}")]
+        public async Task<IActionResult> GetProjectDetails(int projectId)
+        {
+            var result = await _projectService.GetProjectDetailsAsync(projectId);
+            return Response(result);
+        }
+
+        [HttpGet("GetBlocksWithFamiliesByProjectId/{projectId}")]
+        public async Task<IActionResult> GetBlocksWithFamiliesByProjectId(int projectId)
+        {
+            var result = await _projectService.GetBlocksWithFamiliesByProjectId(projectId);
+            return Response(result);
+        }
 
     }
 

--- a/SmartNeighborhoodAPI/Controllers/ProjectController.cs
+++ b/SmartNeighborhoodAPI/Controllers/ProjectController.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using SmartNeighborhoodAPI.Helpers.DTOs.Project;
-using SmartNeighborhoodAPI.Services;
+﻿using SmartNeighborhoodAPI.Helpers.DTOs.Project;
 
 namespace SmartNeighborhoodAPI.Controllers
 {
@@ -49,31 +47,31 @@ namespace SmartNeighborhoodAPI.Controllers
             return Response(result);
         }
 
-        [HttpPost("assign-team/{projectId:int}")]
+        [HttpPost("AssignTeamToProject/{projectId:int}")]
         public async Task<IActionResult> AssignTeamToProject(int projectId, [FromQuery] int teamId)
         {
             var result = await _projectService.AssignTeamToProjectAsync(projectId, teamId);
             return Response(result);
         }
 
-        [HttpPost("assign-family/{projectId:int}")]
+        [HttpPost("AssignFamilyToProject/{projectId:int}")]
         public async Task<IActionResult> AssignFamilyToProject(int projectId, [FromQuery] int familyId)
         {
             var result = await _projectService.AssignFamilyToProjectAsync(projectId, familyId);
             return Response(result);
         }
 
-        [HttpGet("details/{projectId}")]
-        public async Task<IActionResult> GetProjectDetails(int projectId)
+        [HttpGet("GetProjectBlocksWithBeneficiaryFamilies/{projectId}")]
+        public async Task<IActionResult> GetProjectBlocksWithBeneficiaryFamilies(int projectId)
         {
-            var result = await _projectService.GetProjectDetailsAsync(projectId);
+            var result = await _projectService.GetProjectBlocksWithBeneficiaryFamilies(projectId);
             return Response(result);
         }
 
-        [HttpGet("GetBlocksWithFamiliesByProjectId/{projectId}")]
-        public async Task<IActionResult> GetBlocksWithFamiliesByProjectId(int projectId)
+        [HttpGet("GetProjectTeam/{projectId}")]
+        public async Task<IActionResult> GetProjectTeam(int projectId)
         {
-            var result = await _projectService.GetBlocksWithFamiliesByProjectId(projectId);
+            var result = await _projectService.GetProjectTeam(projectId);
             return Response(result);
         }
 

--- a/SmartNeighborhoodAPI/Controllers/TeamsController.cs
+++ b/SmartNeighborhoodAPI/Controllers/TeamsController.cs
@@ -48,10 +48,10 @@
             return Response(result);
         }
 
-        [HttpGet("by-team/{teamId:int}")]
-        public async Task<IActionResult> GetProjectsByTeamId(int teamId)
+        [HttpGet("GetTeamProjects/{teamId:int}")]
+        public async Task<IActionResult> GetTeamProjects(int teamId)
         {
-            var result = await _TeamsService.GetProjectsByTeamIdAsync(teamId);
+            var result = await _TeamsService.GetTeamProjects(teamId);
             return Response(result);
         }
     }

--- a/SmartNeighborhoodAPI/Helpers/DTOs/Project/BeneficiaryFamilies.cs
+++ b/SmartNeighborhoodAPI/Helpers/DTOs/Project/BeneficiaryFamilies.cs
@@ -1,0 +1,11 @@
+﻿using SmartNeighborhoodAPI.Helpers.DTOs.Families;
+
+namespace SmartNeighborhoodAPI.Helpers.DTOs.Project
+{
+    public class BeneficiaryFamilies
+    {
+        public int BlockId { get; set; }
+        public string BlockName { get; set; }
+        public List<FamilyDetailsDto> Families { get; set; }
+    }
+}

--- a/SmartNeighborhoodAPI/Helpers/DTOs/Project/ProjectDetailsDto.cs
+++ b/SmartNeighborhoodAPI/Helpers/DTOs/Project/ProjectDetailsDto.cs
@@ -1,0 +1,25 @@
+﻿using SmartNeighborhoodAPI.Helpers.DTOs.Families;
+using SmartNeighborhoodAPI.Helpers.DTOs.Teams;
+
+namespace SmartNeighborhoodAPI.Helpers.DTOs.Project
+{
+    public class ProjectDetailsDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string? Description { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public string ProjectStatus { get; set; }
+        public string ProjectPriority { get; set; }
+        public double? Budget { get; set; }
+
+        public CustomPersonDto Manager { get; set; }
+        public ProjectCatogory ProjectCatgory { get; set; }
+
+        public List<CustomTeamDto> Teams { get; set; }
+        public List<BeneficiaryFamilies> BeneficiaryFamilies { get; set; }
+
+
+    }
+}

--- a/SmartNeighborhoodAPI/Helpers/DTOs/Teams/CustomTeamDto.cs
+++ b/SmartNeighborhoodAPI/Helpers/DTOs/Teams/CustomTeamDto.cs
@@ -6,6 +6,6 @@ namespace SmartNeighborhoodAPI.Helpers.DTOs.Teams
     {
         public int Id { get; set; }
         public string Name { get; set; }
-        public List<TeamMemberDetailsDto> Members { get; set; }
+        public List<TeamMemberDetailsDto> TeamMembers { get; set; }
     }
 }

--- a/SmartNeighborhoodAPI/Services/ProjectService.cs
+++ b/SmartNeighborhoodAPI/Services/ProjectService.cs
@@ -2,7 +2,9 @@
 using Microsoft.Extensions.Logging;
 using OurProjectSmartNeiborhood.Entites;
 using SmartNeighborhoodAPI.Entites;
+using SmartNeighborhoodAPI.Helpers.DTOs.Families;
 using SmartNeighborhoodAPI.Helpers.DTOs.Project;
+using SmartNeighborhoodAPI.Helpers.DTOs.Teams;
 namespace SmartNeighborhoodAPI.Services
 {
     public class ProjectService
@@ -296,6 +298,117 @@ namespace SmartNeighborhoodAPI.Services
 
             _logger.LogInformation("Successfully assigned Family {FamilyId} to Project {ProjectId}.", familyId, projectId);
             return ApiResponse<string>.Success("تم ربط الأسرة بالمشروع بنجاح.");
+        }
+        public async Task<ApiResponse<ProjectDetailsDto>> GetProjectDetailsAsync(int projectId)
+        {
+            var project = await _context.Projects
+                .Select(x => new ProjectDetailsDto
+                {
+                    Id = x.Id,
+                    Name = x.Name, 
+                    Description = x.Description,
+                    StartDate = x.StartDate,
+                    EndDate = x.EndDate,
+                    ProjectStatus = GetDisplayName(x.ProjectStatus),
+                    ProjectPriority = GetDisplayName(x.ProjectPriority),
+                    Budget = x.Budget,
+                    Manager = new CustomPersonDto
+                    {
+                        Id = x.Manager.Id,
+                        FullName = x.Manager.FullName
+                    },
+                    ProjectCatgory = x.ProjectCatogory,
+                    Teams = x.ProjectTeams.Select(pt => new CustomTeamDto
+                    {
+                        Id = pt.Team.Id,
+                        Name = pt.Team.Name,
+                        Members = pt.Team.TeamMembers.Select(tm => new TeamMemberDetailsDto
+                        {
+                            PersonId = tm.PersonId,
+                            TeamMemberId = tm.Id,
+                            TeamId = tm.TeamId,
+                            TeamName = tm.Team.Name,
+                            PersonName = tm.Person.FullName,
+                            DateOfJoin = tm.DateOfJoin,
+                            TeamRoleId = tm.TeamRoleId,
+                            TeamRoleName = tm.TeamRole.Name
+                        }).ToList()
+                    }).ToList(),
+                    //BeneficiaryFamilies = x.ProjectFamilies.Select(pf => new CustomPro
+                    //{
+                    //    Id = pf.Family.Id,
+                    //    Name = pf.Family.Name,
+                    //    Address = pf.Family.Address,
+                    //    PhoneNumber = pf.Family.PhoneNumber,
+                    //    MembersCount = pf.Family.MembersCount
+                    //}).ToList()
+
+                })
+                .FirstOrDefaultAsync(p => p.Id == projectId);
+
+            if (project == null)
+            {
+                return ApiResponse<ProjectDetailsDto>.Error(HttpStatusCode.NotFound, "Project not found.");
+            }
+
+            return ApiResponse<ProjectDetailsDto>.Success(project);
+        }
+
+        // Reoptimize this function and query
+        public async Task<ApiResponse<List<BeneficiaryFamilies>>> GetBlocksWithFamiliesByProjectId(int projectId)
+        {
+            var isProjectExists = await _context.Projects.AnyAsync(x => x.Id == projectId);
+
+            if (!isProjectExists)
+            {
+                _logger.LogWarning("Project with ID {ProjectId} not found.", projectId);
+                return ApiResponse<List<BeneficiaryFamilies>>.Error(HttpStatusCode.NotFound, "المشروع غير موجود");
+            }
+
+            _logger.LogInformation("Fetching block families for project with ID {ProjectId}", projectId);
+
+            var blockFamilies = await _context.Families
+                .Where(f => f.ProjectFamilies.Any(pf => pf.ProjectID == projectId))
+                .Include(f => f.Block)
+                .Include(f => f.FamilyCatgory)
+                .Include(f => f.FamilyType)
+                .Include(f => f.FamilyMembers)
+                    .ThenInclude(fm => fm.Person)
+                .AsNoTracking()
+                .ToListAsync();
+
+            var grouped = blockFamilies
+                .GroupBy(f => new { f.BlockId, f.Block.Name })
+                .Select(g => new BeneficiaryFamilies
+                {
+                    BlockId = g.Key.BlockId,
+                    BlockName = g.Key.Name,
+                    Families = g.Select(f =>
+                    {
+                        var head = f.FamilyMembers.FirstOrDefault(x => x.MemberFamilyRoleId == 1);
+
+                        return new FamilyDetailsDto
+                        {
+                            Id = f.Id,
+                            Name = f.Name,
+                            BlockId = f.BlockId,
+                            BlockName = f.Block.Name,
+                            FamilyCatgoryId = f.FamilyCatgoryId,
+                            FamilyCatgoryName = f.FamilyCatgory.Name,
+                            FamilyTypeId = f.FamilyTypeId,
+                            FamilyTypeName = f.FamilyType.Name,
+                            Location = f.Location,
+                            FamilyNotes = f.FamilyNotes,
+                            FamilyHeadId = head.Id,
+                            FamilyHeadName = head.Person.FullName,
+                            PhoneNumber = head.Person.PhoneNumber,
+                        };
+                    }).ToList()
+                })
+                .ToList();
+
+            _logger.LogInformation("Retrieved {Count} grouped blocks with families for project ID {ProjectId}.", grouped.Count, projectId);
+            return ApiResponse<List<BeneficiaryFamilies>>.Success(grouped, "تم جلب العائلات حسب البلوك بنجاح");
         }
 
         private static string GetDisplayName<T>(T enumValue)

--- a/SmartNeighborhoodAPI/Services/ProjectService.cs
+++ b/SmartNeighborhoodAPI/Services/ProjectService.cs
@@ -281,6 +281,15 @@ namespace SmartNeighborhoodAPI.Services
                 return ApiResponse<string>.Error(HttpStatusCode.NotFound, "الأسرة غير موجودة.");
             }
 
+            var isAlreadyAssigned = await _context.ProjectFamilies
+                .AnyAsync(pf => pf.ProjectID == projectId && pf.FamilyID == familyId);
+
+            if (isAlreadyAssigned)
+            {
+                _logger.LogWarning("Family {FamilyId} is already assigned to Project {ProjectId}.", familyId, projectId);
+                return ApiResponse<string>.Error(HttpStatusCode.Conflict, "هذه الأسرة مرتبطة بالفعل بهذا المشروع.");
+            }
+
             var projectFamily = new ProjectFamily
             {
                 FamilyID = familyId,
@@ -299,63 +308,9 @@ namespace SmartNeighborhoodAPI.Services
             _logger.LogInformation("Successfully assigned Family {FamilyId} to Project {ProjectId}.", familyId, projectId);
             return ApiResponse<string>.Success("تم ربط الأسرة بالمشروع بنجاح.");
         }
-        public async Task<ApiResponse<ProjectDetailsDto>> GetProjectDetailsAsync(int projectId)
-        {
-            var project = await _context.Projects
-                .Select(x => new ProjectDetailsDto
-                {
-                    Id = x.Id,
-                    Name = x.Name, 
-                    Description = x.Description,
-                    StartDate = x.StartDate,
-                    EndDate = x.EndDate,
-                    ProjectStatus = GetDisplayName(x.ProjectStatus),
-                    ProjectPriority = GetDisplayName(x.ProjectPriority),
-                    Budget = x.Budget,
-                    Manager = new CustomPersonDto
-                    {
-                        Id = x.Manager.Id,
-                        FullName = x.Manager.FullName
-                    },
-                    ProjectCatgory = x.ProjectCatogory,
-                    Teams = x.ProjectTeams.Select(pt => new CustomTeamDto
-                    {
-                        Id = pt.Team.Id,
-                        Name = pt.Team.Name,
-                        Members = pt.Team.TeamMembers.Select(tm => new TeamMemberDetailsDto
-                        {
-                            PersonId = tm.PersonId,
-                            TeamMemberId = tm.Id,
-                            TeamId = tm.TeamId,
-                            TeamName = tm.Team.Name,
-                            PersonName = tm.Person.FullName,
-                            DateOfJoin = tm.DateOfJoin,
-                            TeamRoleId = tm.TeamRoleId,
-                            TeamRoleName = tm.TeamRole.Name
-                        }).ToList()
-                    }).ToList(),
-                    //BeneficiaryFamilies = x.ProjectFamilies.Select(pf => new CustomPro
-                    //{
-                    //    Id = pf.Family.Id,
-                    //    Name = pf.Family.Name,
-                    //    Address = pf.Family.Address,
-                    //    PhoneNumber = pf.Family.PhoneNumber,
-                    //    MembersCount = pf.Family.MembersCount
-                    //}).ToList()
-
-                })
-                .FirstOrDefaultAsync(p => p.Id == projectId);
-
-            if (project == null)
-            {
-                return ApiResponse<ProjectDetailsDto>.Error(HttpStatusCode.NotFound, "Project not found.");
-            }
-
-            return ApiResponse<ProjectDetailsDto>.Success(project);
-        }
 
         // Reoptimize this function and query
-        public async Task<ApiResponse<List<BeneficiaryFamilies>>> GetBlocksWithFamiliesByProjectId(int projectId)
+        public async Task<ApiResponse<List<BeneficiaryFamilies>>> GetProjectBlocksWithBeneficiaryFamilies(int projectId)
         {
             var isProjectExists = await _context.Projects.AnyAsync(x => x.Id == projectId);
 
@@ -410,7 +365,44 @@ namespace SmartNeighborhoodAPI.Services
             _logger.LogInformation("Retrieved {Count} grouped blocks with families for project ID {ProjectId}.", grouped.Count, projectId);
             return ApiResponse<List<BeneficiaryFamilies>>.Success(grouped, "تم جلب العائلات حسب البلوك بنجاح");
         }
+        public async Task<ApiResponse<List<CustomTeamDto>>> GetProjectTeam(int projectId)
+        {
+            var isProjectExists = await _context.Projects.AnyAsync(x => x.Id == projectId);
 
+            if (!isProjectExists)
+            {
+                _logger.LogWarning("Project with ID {ProjectId} not found.", projectId);
+                return ApiResponse<List<CustomTeamDto>>.Error(HttpStatusCode.NotFound, "المشروع غير موجود");
+            }
+            _logger.LogInformation("Fetching project teams for project with ID {ProjectId}", projectId);
+
+            var teams = await _context.ProjectTeams
+                .Where(pt => pt.ProjectId == projectId)
+                .Select(pt => new CustomTeamDto
+                {
+                    Id = pt.Team.Id,
+                    Name = pt.Team.Name,
+                    TeamMembers = pt.Team.TeamMembers.Select(tm => new TeamMemberDetailsDto
+                    {
+                        TeamMemberId = tm.Id,
+                        TeamId = tm.TeamId,
+                        TeamName = tm.Team.Name,
+                        PersonId = tm.PersonId,
+                        PersonName = tm.Person.FullName,
+                        DateOfJoin = tm.DateOfJoin,
+                        TeamRoleId = tm.TeamRoleId,
+                        TeamRoleName = tm.TeamRole.Name
+                    }).ToList()
+                })
+                .ToListAsync();
+
+            if (teams == null || teams.Count == 0)
+            {
+                return ApiResponse<List<CustomTeamDto>>.Error(HttpStatusCode.NotFound, "لا توجد فرق مرتبطة بهذا المشروع");
+            }
+
+            return ApiResponse<List<CustomTeamDto>>.Success(teams, "تم جلب الفرق بنجاح");
+        }
         private static string GetDisplayName<T>(T enumValue)
         {
             var memberInfo = typeof(T).GetMember(enumValue.ToString()).FirstOrDefault();

--- a/SmartNeighborhoodAPI/Services/TeamsService.cs
+++ b/SmartNeighborhoodAPI/Services/TeamsService.cs
@@ -98,7 +98,7 @@ namespace SmartNeighborhoodAPI.Services
                 {
                     Id = t.Id,
                     Name = t.Name,
-                    Members = t.TeamMembers.Select(tm => new TeamMemberDetailsDto
+                    TeamMembers = t.TeamMembers.Select(tm => new TeamMemberDetailsDto
                     {
                         TeamMemberId = tm.Id,
                         PersonId = tm.PersonId,
@@ -201,7 +201,7 @@ namespace SmartNeighborhoodAPI.Services
             _logger.LogInformation("Team with ID {TeamId} updated successfully", teamId);
             return ApiResponse<TeamDto>.Success(dto, "تم تحديث الفريق بنجاح");
         }
-        public async Task<ApiResponse<IEnumerable<ReturnProjectDto>>> GetProjectsByTeamIdAsync(int teamId)
+        public async Task<ApiResponse<IEnumerable<ReturnProjectDto>>> GetTeamProjects(int teamId)
         {
             _logger.LogInformation("Fetching projects assigned to team with ID {TeamId}.", teamId);
 


### PR DESCRIPTION
- Implemented `GetProjectBlocksWithBeneficiaryFamilies` to retrieve blocks with associated beneficiary families for a given project.
- Implemented `GetProjectTeam` to return the team members assigned to a specific project.
- Both methods include validation to check if the project exists before executing the query.
- Arabic success messages are returned for end users, while logs remain in English for consistent debugging.
- Structured queries using optimized LINQ for better performance and clarity.