### PR TITLE
Fix: Add dateReceived to projectFamily table and include it in family…

### DIFF
--- a/SmartNeighborhoodAPI/Entites/ProjectFamily.cs
+++ b/SmartNeighborhoodAPI/Entites/ProjectFamily.cs
@@ -3,6 +3,7 @@
     public class ProjectFamily
     {
         public int Id { get; set; }
+        public DateTime dateReceived { get; set; }
 
         public int ProjectID { get; set; }
         public Project Project { get; set; }

--- a/SmartNeighborhoodAPI/Helpers/DTOs/ProjectFamily/ProjectFamilyDto.cs
+++ b/SmartNeighborhoodAPI/Helpers/DTOs/ProjectFamily/ProjectFamilyDto.cs
@@ -5,6 +5,5 @@
         public int Id { get; set; }
         public string Name { get; set; }
         public string dateReceived { get; set; }
-        public string Notes { get; set; }
     }
 }

--- a/SmartNeighborhoodAPI/Migrations/20250712110741_Add-dateReceived-to-ProjectFamily.Designer.cs
+++ b/SmartNeighborhoodAPI/Migrations/20250712110741_Add-dateReceived-to-ProjectFamily.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SmartNeighborhoodAPI;
 
@@ -11,9 +12,11 @@ using SmartNeighborhoodAPI;
 namespace SmartNeighborhoodAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250712110741_Add-dateReceived-to-ProjectFamily")]
+    partial class AdddateReceivedtoProjectFamily
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SmartNeighborhoodAPI/Migrations/20250712110741_Add-dateReceived-to-ProjectFamily.cs
+++ b/SmartNeighborhoodAPI/Migrations/20250712110741_Add-dateReceived-to-ProjectFamily.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartNeighborhoodAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdddateReceivedtoProjectFamily : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "dateReceived",
+                table: "ProjectFamilies",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash", "SecurityStamp" },
+                values: new object[] { "9c4c3d08-b706-48fe-9cfa-ea69c87a65c7", "AQAAAAIAAYagAAAAEEelOrtut6rMF5dDIfCELHkB7Jz4Uw6FvlIJC9Vq4XDshpVwL0ALLpG/UeikEeXyPQ==", "f8294112-0494-4952-bb2e-d38292c3782f" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "dateReceived",
+                table: "ProjectFamilies");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash", "SecurityStamp" },
+                values: new object[] { "165e8ffa-cccc-4ed8-92b7-94b2dc1ea589", "AQAAAAIAAYagAAAAEMD5L5LkRdI9vB+zVujIFMnS/vB4jWLdciUz0RSaQGKkcpmAmdXI+hEOsRxd4qneYA==", "96e9d731-24c0-469c-a11e-351382e592f9" });
+        }
+    }
+}

--- a/SmartNeighborhoodAPI/Services/FamilyService.cs
+++ b/SmartNeighborhoodAPI/Services/FamilyService.cs
@@ -248,7 +248,8 @@ namespace SmartNeighborhoodAPI.Services
                     Assistances = x.ProjectFamilies.Select(pfm => new Assistances
                     {
                         Id = pfm.Project.Id,
-                        Name = pfm.Project.Name
+                        Name = pfm.Project.Name,
+                        dateReceived = pfm.dateReceived.ToString(),
                     }).ToList()
                 })
                 .FirstOrDefaultAsync(x => x.Id == id);

--- a/SmartNeighborhoodAPI/Services/ProjectService.cs
+++ b/SmartNeighborhoodAPI/Services/ProjectService.cs
@@ -293,7 +293,8 @@ namespace SmartNeighborhoodAPI.Services
             var projectFamily = new ProjectFamily
             {
                 FamilyID = familyId,
-                ProjectID = projectId
+                ProjectID = projectId,
+                dateReceived = DateTime.Now
             };
 
             await _context.ProjectFamilies.AddAsync(projectFamily);


### PR DESCRIPTION
…Details endpoint

- Introduced a new `dateReceived` property in the `ProjectFamily` class.
- Updated `Assistances` class to include `dateReceived` as a string.
- Standardized table mappings in `ApplicationDbContextModelSnapshot.cs` by removing `(string)null`.
- Added `dateReceived` column to the `ProjectFamilies` table via a new migration.
- Initialized `dateReceived` with the current date and time in `ProjectService.cs`.
- Included `dateReceived` in data retrieval logic in `FamilyService.cs`.
- Updated `ConcurrencyStamp`, `PasswordHash`, and `SecurityStamp` for `AppUser` in migration.