### PR TITLE
Refactor(ResidntailNeighborhood) ChangeManagerAsync and DTOs for clarity

### DIFF
--- a/SmartNeighborhoodAPI/SmartNeighborhoodAPI.sln
+++ b/SmartNeighborhoodAPI/SmartNeighborhoodAPI.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartNeighborhoodAPI", "SmartNeighborhoodAPI.csproj", "{298B528C-C313-A0A0-88B2-A89FDF9D0679}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{298B528C-C313-A0A0-88B2-A89FDF9D0679}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{298B528C-C313-A0A0-88B2-A89FDF9D0679}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{298B528C-C313-A0A0-88B2-A89FDF9D0679}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{298B528C-C313-A0A0-88B2-A89FDF9D0679}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A9EA4A2D-3515-4A83-8070-F0C6B233E642}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Refactored ChangeManagerAsync to accept neighborhood ID as a parameter instead of within ChangeResidentialManagerDto. Updated controller, service, and logging accordingly. Removed neighborhoodId from ChangeResidentialManagerDto. Also removed Units property from ReturnResidentialNeighborhoodDto and its mapping.