### PR TITLE
Add manager-specific endpoints for neighborhood management

### DIFF
--- a/SmartNeighborhoodAPI/Controllers/V1/ResidentialNeighborhoodsController.cs
+++ b/SmartNeighborhoodAPI/Controllers/V1/ResidentialNeighborhoodsController.cs
@@ -5,14 +5,14 @@ using SmartNeighborhoodAPI.Helpers;
 using SmartNeighborhoodAPI.Helpers.DTOs.ResidentialNeighborhood;
 using SmartNeighborhoodAPI.Interfaces;
 using static SmartNeighborhoodAPI.Helpers.Router;
+using System.Security.Claims;
 
 namespace SmartNeighborhoodAPI.Controllers.V1
 {
-    [Authorize(Roles = Role.Admin)]
     [ApiController]
     [ApiVersion("1.0")]
     [SwaggerTag("Residential Neighborhoods management")]
-    public class ResidentialNeighborhoodsController : ControllerBase
+    public class ResidentialNeighborhoodsController : AppControllerBase
     {
         private readonly IResidentialNeighborhoodService _service;
 
@@ -38,6 +38,7 @@ namespace SmartNeighborhoodAPI.Controllers.V1
             => Response(await _service.GetByIdAsync(id));
 
         [HttpPost(ResidentialNeighborhoods.Add)]
+        [Authorize(Roles = Role.Admin)]
         [SwaggerOperation(Summary = "Create residential neighborhood (Admin only)")]
         public async Task<IActionResult> Create(
             [FromBody] CreateResidentialNeighborhoodDto dto)
@@ -50,9 +51,8 @@ namespace SmartNeighborhoodAPI.Controllers.V1
             [FromBody] UpdateResidentialNeighborhoodDto dto)
             => Response(await _service.UpdateAsync(id, dto));
 
-
-
         [HttpPost(ResidentialNeighborhoods.ChangeManager)]
+        [Authorize(Roles = Role.Admin)]
         [SwaggerOperation(Summary = "Change residential neighborhood manager (Admin only)")]
         public async Task<IActionResult> ChangeManager(
             int id,
@@ -60,6 +60,7 @@ namespace SmartNeighborhoodAPI.Controllers.V1
             => Response(await _service.ChangeManagerAsync(id, dto));
 
         [HttpGet(ResidentialNeighborhoods.Dashboard)]
+        [Authorize(Roles = Role.Admin)]
         [SwaggerOperation(Summary = "Get residential neighborhood dashboard statistics (Admin only)")]
         public async Task<IActionResult> GetDashboard(CancellationToken ct)
             => Response(await _service.GetDashboardAsync(ct));
@@ -68,5 +69,31 @@ namespace SmartNeighborhoodAPI.Controllers.V1
         [SwaggerOperation(Summary = "Get units (Admin only)")]
         public async Task<IActionResult> GetUnitsAsync(int id)
             => Response(await _service.GetUnitsAsync(id));
+
+        [HttpGet(ResidentialNeighborhoods.GetMyDashboard)]
+        [SwaggerOperation(
+            Summary = "Get my dashboard statistics (Manager only)",
+            Description = "Returns dashboard statistics for the authenticated residential neighborhood manager, including total neighborhoods, units, and blocks they manage.")]
+        [ProducesResponseType(typeof(ApiResponse<ResidentialNeighborhoodManagerDashboardDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetMyDashboard(CancellationToken ct)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return Response(await _service.GetMyDashboardAsync(userId, ct));
+        }
+
+        [HttpGet(ResidentialNeighborhoods.GetMyNeighborhoods)]
+        [SwaggerOperation(
+            Summary = "Get my managed neighborhoods (Manager only)",
+            Description = "Returns all residential neighborhoods managed by the authenticated user, including residential units and blocks summary.")]
+        [ProducesResponseType(typeof(ApiResponse<List<ReturnResidentialNeighborhoodDto>>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetMyNeighborhoods(CancellationToken ct)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return Response(await _service.GetMyNeighborhoodsAsync(userId, ct));
+        }
     }
 }

--- a/SmartNeighborhoodAPI/Helpers/DTOs/ResidentialNeighborhood/ResidentialNeighborhoodManagerDashboardDto.cs
+++ b/SmartNeighborhoodAPI/Helpers/DTOs/ResidentialNeighborhood/ResidentialNeighborhoodManagerDashboardDto.cs
@@ -1,0 +1,9 @@
+namespace SmartNeighborhoodAPI.Helpers.DTOs.ResidentialNeighborhood
+{
+    public class ResidentialNeighborhoodManagerDashboardDto
+    {
+        public int TotalNeighborhoods { get; set; }
+        public int TotalUnits { get; set; }
+        public int TotalBlocks { get; set; }
+    }
+}

--- a/SmartNeighborhoodAPI/Helpers/Router.cs
+++ b/SmartNeighborhoodAPI/Helpers/Router.cs
@@ -36,6 +36,10 @@ namespace SmartNeighborhoodAPI.Helpers
             public const string ChangeManager = Prefix + "/{id:int}/manager";
             public const string Dashboard = Prefix + "/dashboard";
             public const string Units = Prefix + "/{id:int}/units";
+            
+            // Manager-specific endpoints
+            public const string GetMyNeighborhoods = Prefix + "/me";
+            public const string GetMyDashboard = Prefix + "/me/dashboard";
         }
 
         public static class Blocks

--- a/SmartNeighborhoodAPI/Interfaces/IResidentialNeighborhoodService.cs
+++ b/SmartNeighborhoodAPI/Interfaces/IResidentialNeighborhoodService.cs
@@ -15,6 +15,9 @@ namespace SmartNeighborhoodAPI.Interfaces
         Task<ApiResponse<string>> UpdateAsync(int id, UpdateResidentialNeighborhoodDto dto);
         Task<ApiResponse<ReturnResidentialNeighborhoodDto>> ChangeManagerAsync(int id, ChangeResidentialManagerDto dto);
         Task<ApiResponse<ReturnResidentialUnitDto>> GetUnitsAsync(int id);
-
+        
+        // Manager-specific endpoints
+        Task<ApiResponse<ResidentialNeighborhoodManagerDashboardDto>> GetMyDashboardAsync(string userId, CancellationToken ct = default);
+        Task<ApiResponse<List<ReturnResidentialNeighborhoodDto>>> GetMyNeighborhoodsAsync(string userId, CancellationToken ct = default);
     }
 }

--- a/SmartNeighborhoodAPI/Services/ResidentialNeighborhoodService.cs
+++ b/SmartNeighborhoodAPI/Services/ResidentialNeighborhoodService.cs
@@ -381,6 +381,82 @@ namespace SmartNeighborhoodAPI.Services
 
             return ApiResponse<ReturnResidentialUnitDto>.Success(entity.ToResidentialUnitDto(), "تم جلب الوحدات السكنية بنجاح");
         }
+
+        public async Task<ApiResponse<ResidentialNeighborhoodManagerDashboardDto>> GetMyDashboardAsync(string userId, CancellationToken ct = default)
+        {
+            _logger.LogInformation("Fetching dashboard statistics for manager with userId: {UserId}", userId);
+
+            // Query neighborhoods managed by this user with aggregated statistics
+            var statistics = await _context.ResidentialNeighborhoods
+                .AsNoTracking()
+                .Where(n => n.NeighborhoodManagerId == userId)
+                .Select(n => new
+                {
+                    NeighborhoodId = n.Id,
+                    UnitsCount = n.ResidentialUnits.Count,
+                    BlocksCount = n.ResidentialUnits.SelectMany(u => u.Blocks).Count()
+                })
+                .ToListAsync(ct);
+
+            if (!statistics.Any())
+            {
+                _logger.LogWarning("No neighborhoods found for manager with userId: {UserId}", userId);
+                return ApiResponse<ResidentialNeighborhoodManagerDashboardDto>.Success(
+                    new ResidentialNeighborhoodManagerDashboardDto
+                    {
+                        TotalNeighborhoods = 0,
+                        TotalUnits = 0,
+                        TotalBlocks = 0
+                    },
+                    "لا توجد أحياء سكنية مرتبطة بهذا المدير"
+                );
+            }
+
+            var dashboard = new ResidentialNeighborhoodManagerDashboardDto
+            {
+                TotalNeighborhoods = statistics.Count,
+                TotalUnits = statistics.Sum(s => s.UnitsCount),
+                TotalBlocks = statistics.Sum(s => s.BlocksCount)
+            };
+
+            _logger.LogInformation("Dashboard statistics retrieved successfully for manager {UserId}: {Neighborhoods} neighborhoods, {Units} units, {Blocks} blocks",
+                userId, dashboard.TotalNeighborhoods, dashboard.TotalUnits, dashboard.TotalBlocks);
+
+            return ApiResponse<ResidentialNeighborhoodManagerDashboardDto>.Success(dashboard, "تم جلب إحصائيات لوحة التحكم بنجاح");
+        }
+
+        public async Task<ApiResponse<List<ReturnResidentialNeighborhoodDto>>> GetMyNeighborhoodsAsync(string userId, CancellationToken ct = default)
+        {
+            _logger.LogInformation("Fetching neighborhoods for manager with userId: {UserId}", userId);
+
+            var neighborhoods = await _context.ResidentialNeighborhoods
+                .AsNoTracking()
+                .Where(n => n.NeighborhoodManagerId == userId)
+                .Include(n => n.NeighborhoodManager)
+                    .ThenInclude(nm => nm.Person)
+                .Include(n => n.ResidentialUnits)
+                    .ThenInclude(u => u.UnitManager)
+                        .ThenInclude(um => um.Person)
+                .Include(n => n.ResidentialUnits)
+                    .ThenInclude(u => u.Blocks)
+                .OrderBy(n => n.Name)
+                .ToListAsync(ct);
+
+            if (!neighborhoods.Any())
+            {
+                _logger.LogWarning("No neighborhoods found for manager with userId: {UserId}", userId);
+                return ApiResponse<List<ReturnResidentialNeighborhoodDto>>.Success(
+                    new List<ReturnResidentialNeighborhoodDto>(),
+                    "لا توجد أحياء سكنية مرتبطة بهذا المدير"
+                );
+            }
+
+            var result = neighborhoods.Select(n => n.ToDto()).ToList();
+
+            _logger.LogInformation("Retrieved {Count} neighborhoods for manager with userId: {UserId}", result.Count, userId);
+
+            return ApiResponse<List<ReturnResidentialNeighborhoodDto>>.Success(result, "تم جلب الأحياء السكنية بنجاح");
+        }
     }
 
 }


### PR DESCRIPTION
This commit introduces new functionalities for managing residential neighborhoods tailored for users with the "Manager" role. Key changes include:

- Added `ResidentialNeighborhoodManagerDashboardDto` to encapsulate dashboard statistics for managers.
- Updated `ResidentialNeighborhoodsController` with new methods for creating neighborhoods, changing managers, and accessing dashboard statistics, restricted to "Admin" role.
- Defined new routes in the `Router` class for manager-specific endpoints.
- Enhanced `IResidentialNeighborhoodService` interface with methods for fetching managed neighborhoods and dashboard statistics.
- Implemented new service methods in `ResidentialNeighborhoodService` to query statistics and neighborhoods for authenticated managers.

These changes improve the application's management capabilities for residential neighborhoods.