### PR TITLE
Add unit manager endpoints and update dashboard DTOs

### DIFF
--- a/SmartNeighborhoodAPI/Controllers/V1/ResidentialUnitsController.cs
+++ b/SmartNeighborhoodAPI/Controllers/V1/ResidentialUnitsController.cs
@@ -9,7 +9,6 @@ using System.Security.Claims;
 namespace SmartNeighborhoodAPI.Controllers.V1
 {
     [SwaggerTag("Residential Units management endpoints")]
-    [Authorize(Roles = Role.Admin + "," + Role.UnitManager)]
     public class ResidentialUnitsController : AppControllerBase
     {
         private readonly ResidentialUnitService _unitServices;
@@ -96,12 +95,41 @@ namespace SmartNeighborhoodAPI.Controllers.V1
 
         [HttpGet(Router.ResidentialUnits.Dashboard)]
         [MapToApiVersion("1.0")]
-        [SwaggerOperation(Summary = "Get residential units dashboard", Description = "Returns dashboard statistics for residential units.")]
+        [Authorize(Roles = Role.Admin)]
+        [SwaggerOperation(Summary = "Get residential units dashboard (Admin only)", Description = "Returns dashboard statistics for residential units.")]
         [ProducesResponseType(typeof(ResidentialUnitDashboardDto), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetDashboardAsync()
         {
             return Response(await _unitServices.GetDashboardAsync());
+        }
+
+        [HttpGet(Router.ResidentialUnits.GetMyDashboard)]
+        [MapToApiVersion("1.0")]
+        [SwaggerOperation(
+            Summary = "Get my dashboard statistics (Unit Manager only)",
+            Description = "Returns dashboard statistics for the authenticated unit manager, including total families and blocks they manage.")]
+        [ProducesResponseType(typeof(ApiResponse<ResidentialUnitManagerDashboardDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetMyDashboard(CancellationToken ct)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return Response(await _unitServices.GetMyDashboardAsync(userId, ct));
+        }
+
+        [HttpGet(Router.ResidentialUnits.GetMyUnits)]
+        [MapToApiVersion("1.0")]
+        [SwaggerOperation(
+            Summary = "Get my managed residential units (Unit Manager only)",
+            Description = "Returns all residential units managed by the authenticated user, including blocks summary.")]
+        [ProducesResponseType(typeof(ApiResponse<List<ReturnResidentialUnitDto>>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetMyUnits(CancellationToken ct)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return Response(await _unitServices.GetMyUnitsAsync(userId, ct));
         }
 
     }

--- a/SmartNeighborhoodAPI/Helpers/DTOs/ResidentialNeighborhood/ResidentialNeighborhoodManagerDashboardDto.cs
+++ b/SmartNeighborhoodAPI/Helpers/DTOs/ResidentialNeighborhood/ResidentialNeighborhoodManagerDashboardDto.cs
@@ -2,7 +2,7 @@ namespace SmartNeighborhoodAPI.Helpers.DTOs.ResidentialNeighborhood
 {
     public class ResidentialNeighborhoodManagerDashboardDto
     {
-        public int TotalNeighborhoods { get; set; }
+        public int TotalFamilies { get; set; }
         public int TotalUnits { get; set; }
         public int TotalBlocks { get; set; }
     }

--- a/SmartNeighborhoodAPI/Helpers/DTOs/ResidentialUnits/ResidentialUnitManagerDashboardDto.cs
+++ b/SmartNeighborhoodAPI/Helpers/DTOs/ResidentialUnits/ResidentialUnitManagerDashboardDto.cs
@@ -1,0 +1,8 @@
+namespace SmartNeighborhoodAPI.Helpers.DTOs.ResidentialUnits
+{
+    public class ResidentialUnitManagerDashboardDto
+    {
+        public int TotalFamilies { get; set; }
+        public int TotalBlocks { get; set; }
+    }
+}

--- a/SmartNeighborhoodAPI/Helpers/Router.cs
+++ b/SmartNeighborhoodAPI/Helpers/Router.cs
@@ -22,6 +22,9 @@ namespace SmartNeighborhoodAPI.Helpers
 
             public const string Blocks = Prefix + "/{unitId:int}/blocks";             
             public const string BlockById = Blocks + "/{blockId:int}";
+            
+            public const string GetMyUnits = Prefix + "/me";
+            public const string GetMyDashboard = Prefix + "/me/dashboard";
         }
 
         public static class ResidentialNeighborhoods
@@ -37,7 +40,6 @@ namespace SmartNeighborhoodAPI.Helpers
             public const string Dashboard = Prefix + "/dashboard";
             public const string Units = Prefix + "/{id:int}/units";
             
-            // Manager-specific endpoints
             public const string GetMyNeighborhoods = Prefix + "/me";
             public const string GetMyDashboard = Prefix + "/me/dashboard";
         }

--- a/SmartNeighborhoodAPI/Services/ResidentialNeighborhoodService.cs
+++ b/SmartNeighborhoodAPI/Services/ResidentialNeighborhoodService.cs
@@ -401,7 +401,6 @@ namespace SmartNeighborhoodAPI.Services
         {
             _logger.LogInformation("Fetching dashboard statistics for manager with userId: {UserId}", userId);
 
-            // Query neighborhoods managed by this user with aggregated statistics
             var statistics = await _context.ResidentialNeighborhoods
                 .AsNoTracking()
                 .Where(n => n.NeighborhoodManagerId == userId)
@@ -409,7 +408,8 @@ namespace SmartNeighborhoodAPI.Services
                 {
                     NeighborhoodId = n.Id,
                     UnitsCount = n.ResidentialUnits.Count,
-                    BlocksCount = n.ResidentialUnits.SelectMany(u => u.Blocks).Count()
+                    BlocksCount = n.ResidentialUnits.SelectMany(u => u.Blocks).Count(),
+                    FamiliesCount = n.ResidentialUnits.SelectMany(u => u.Blocks).SelectMany(b => b.Families).Count()
                 })
                 .ToListAsync(ct);
 
@@ -419,7 +419,7 @@ namespace SmartNeighborhoodAPI.Services
                 return ApiResponse<ResidentialNeighborhoodManagerDashboardDto>.Success(
                     new ResidentialNeighborhoodManagerDashboardDto
                     {
-                        TotalNeighborhoods = 0,
+                        TotalFamilies = 0,
                         TotalUnits = 0,
                         TotalBlocks = 0
                     },
@@ -429,13 +429,13 @@ namespace SmartNeighborhoodAPI.Services
 
             var dashboard = new ResidentialNeighborhoodManagerDashboardDto
             {
-                TotalNeighborhoods = statistics.Count,
+                TotalFamilies = statistics.Sum(s => s.FamiliesCount),
                 TotalUnits = statistics.Sum(s => s.UnitsCount),
                 TotalBlocks = statistics.Sum(s => s.BlocksCount)
             };
 
-            _logger.LogInformation("Dashboard statistics retrieved successfully for manager {UserId}: {Neighborhoods} neighborhoods, {Units} units, {Blocks} blocks",
-                userId, dashboard.TotalNeighborhoods, dashboard.TotalUnits, dashboard.TotalBlocks);
+            _logger.LogInformation("Dashboard statistics retrieved successfully for manager {UserId}: {Families} families, {Units} units, {Blocks} blocks",
+                userId, dashboard.TotalFamilies, dashboard.TotalUnits, dashboard.TotalBlocks);
 
             return ApiResponse<ResidentialNeighborhoodManagerDashboardDto>.Success(dashboard, "تم جلب إحصائيات لوحة التحكم بنجاح");
         }

--- a/SmartNeighborhoodAPI/Services/ResidentialUnitService.cs
+++ b/SmartNeighborhoodAPI/Services/ResidentialUnitService.cs
@@ -513,8 +513,77 @@ namespace SmartNeighborhoodAPI.Services
             });
         }
 
+        public async Task<ApiResponse<ResidentialUnitManagerDashboardDto>> GetMyDashboardAsync(string userId, CancellationToken ct = default)
+        {
+            _logger.LogInformation("Fetching dashboard statistics for unit manager with userId: {UserId}", userId);
 
+            var statistics = await _context.ResidentialUnits
+                .AsNoTracking()
+                .Where(u => u.UnitManagerId == userId)
+                .Select(u => new
+                {
+                    UnitId = u.Id,
+                    BlocksCount = u.Blocks.Count,
+                    FamiliesCount = u.Blocks.SelectMany(b => b.Families).Count()
+                })
+                .ToListAsync(ct);
 
+            if (!statistics.Any())
+            {
+                _logger.LogWarning("No residential units found for manager with userId: {UserId}", userId);
+                return ApiResponse<ResidentialUnitManagerDashboardDto>.Success(
+                    new ResidentialUnitManagerDashboardDto
+                    {
+                        TotalFamilies = 0,
+                        TotalBlocks = 0
+                    },
+                    "لا توجد وحدات سكنية مرتبطة بهذا المدير"
+                );
+            }
+
+            var dashboard = new ResidentialUnitManagerDashboardDto
+            {
+                TotalFamilies = statistics.Sum(s => s.FamiliesCount),
+                TotalBlocks = statistics.Sum(s => s.BlocksCount)
+            };
+
+            _logger.LogInformation("Dashboard statistics retrieved successfully for unit manager {UserId}: {Families} families, {Blocks} blocks",
+                userId, dashboard.TotalFamilies, dashboard.TotalBlocks);
+
+            return ApiResponse<ResidentialUnitManagerDashboardDto>.Success(dashboard, "تم جلب إحصائيات لوحة التحكم بنجاح");
+        }
+
+        public async Task<ApiResponse<List<ReturnResidentialUnitDto>>> GetMyUnitsAsync(string userId, CancellationToken ct = default)
+        {
+            _logger.LogInformation("Fetching residential units for manager with userId: {UserId}", userId);
+
+            var units = await _context.ResidentialUnits
+                .AsNoTracking()
+                .Where(u => u.UnitManagerId == userId)
+                .Include(u => u.UnitManager)
+                    .ThenInclude(um => um.Person)
+                .Include(u => u.Blocks)
+                    .ThenInclude(b => b.BlockManager)
+                        .ThenInclude(bm => bm.Person)
+                .Include(u => u.ResidentialNeighborhood)
+                .OrderBy(u => u.Name)
+                .ToListAsync(ct);
+
+            if (!units.Any())
+            {
+                _logger.LogWarning("No residential units found for manager with userId: {UserId}", userId);
+                return ApiResponse<List<ReturnResidentialUnitDto>>.Success(
+                    new List<ReturnResidentialUnitDto>(),
+                    "لا توجد وحدات سكنية مرتبطة بهذا المدير"
+                );
+            }
+
+            var result = units.Select(u => MapToDto(u)).ToList();
+
+            _logger.LogInformation("Retrieved {Count} residential units for manager with userId: {UserId}", result.Count, userId);
+
+            return ApiResponse<List<ReturnResidentialUnitDto>>.Success(result, "تم جلب الوحدات السكنية بنجاح");
+        }
 
         private ReturnResidentialUnitDto MapToDto(ResidentialUnit unit)
         {


### PR DESCRIPTION
Updated `ResidentialUnitsController` to include new endpoints for unit managers, restricting `GetDashboardAsync` to admin users. Added `GetMyDashboard` and `GetMyUnits` methods for unit managers.

Modified `ResidentialNeighborhoodManagerDashboardDto` to remove `TotalNeighborhoods` and add `TotalFamilies`.

Updated `Router` with new routes for unit manager dashboards.

Refined `ResidentialNeighborhoodService` to focus on families and blocks.

Introduced `GetMyDashboardAsync` in `ResidentialUnitService` for unit manager statistics.

Created `ResidentialUnitManagerDashboardDto` for unit manager dashboard data.